### PR TITLE
fixing osx support "st.Mtim undefined (type *syscall.Stat_t has no field or method Mtim)"

### DIFF
--- a/gfapi/stat_darwin.go
+++ b/gfapi/stat_darwin.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2013, Kaushal M <kshlmster at gmail dot com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package gfapi
+
+import (
+	"syscall"
+)
+
+// getLastModification returns the modification time
+func getLastModification(st *syscall.Stat_t) syscall.Timespec {
+	return st.Mtimespec
+}

--- a/gfapi/stat_linux.go
+++ b/gfapi/stat_linux.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2013, Kaushal M <kshlmster at gmail dot com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package gfapi
+
+import (
+	"syscall"
+)
+
+// getLastModification returns the modification time
+func getLastModification(st *syscall.Stat_t) syscall.Timespec {
+	return st.Mtim
+}

--- a/gfapi/utils.go
+++ b/gfapi/utils.go
@@ -91,7 +91,7 @@ func fileInfoFromStat(st *syscall.Stat_t, name string) os.FileInfo {
 	fs := &fileInfo{
 		name:    path.Base(name),
 		size:    int64(st.Size),
-		modTime: timespecToTime(st.Mtim),
+		modTime: timespecToTime(getLastModification(st)),
 		sys:     st,
 	}
 	fs.mode = os.FileMode(st.Mode & 0777)


### PR DESCRIPTION
Running the current version under OSX the follwing error is returned 
`st.Mtim undefined (type *syscall.Stat_t has no field or method Mtim)`

The syscall.Stat_t has a different implementation on [darwin](https://golang.org/src/syscall/ztypes_darwin_amd64.go?h=Mtimespec)