### PR TITLE
Fixed the gopath for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 A Go language wrapper around gfapi.
 
 To use in your Go program get/download the package with,  
-``$ go get forge.gluster.org/gogfapi/gogfapi.git/gfapi``
+``$ go get github.com/kshlm/gogfapi``
 and import as,  
-``import "forge.gluster.org/gogfapi/gogfapi.git/gfapi"``
+``import "github.com/kshlm/gogfapi"``
 
 and get/download the package with,  
-``$ go get forge.gluster.org/gogfapi/gogfapi.git/gfapi``
+``$ go get github.com/kshlm/gogfapi``
 
 
 [![gogfapi documentation on GoDoc.org](https://godoc.org/forge.gluster.org/gogfapi/gogfapi.git/gfapi?status.png)](http://godoc.org/forge.gluster.org/gogfapi/gogfapi.git/gfapi) for documentation of the api.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Go language wrapper around gfapi.
 To use in your Go program get/download the package with,  
 ``$ go get github.com/kshlm/gogfapi``
 and import as,  
-``import "github.com/kshlm/gogfapi"``
+``import "github.com/kshlm/gogfapi/gfapi"``
 
 and get/download the package with,  
 ``$ go get github.com/kshlm/gogfapi``


### PR DESCRIPTION
Since you said it is moved on the github, I wanted to fix the paths for downloading and importing the package