### PR TITLE
Allow log file to be created in default directory

### DIFF
--- a/gfapi/volume.go
+++ b/gfapi/volume.go
@@ -120,12 +120,13 @@ const (
 // SetLogging sets the path to the logfile for gfapi.
 // The Volume must be initialized before calling.
 //
+// If an empty string "" is passed as 'name', a logfile will be created in
+// default log directory (/var/log/glusterfs)
+//
 // Returns 0 on success and, non 0 and an error on failure.
 func (v *Volume) SetLogging(name string, logLevel LogLevel) (int, error) {
 
 	if name == "" {
-		// a new logfile will be created in default log directory associated
-		// with the glusterfs installation (/var/log/glusterfs)
 		ret, err := C.glfs_set_logging(v.fs, nil, C.int(logLevel))
 		return int(ret), err
 	}

--- a/gfapi/volume.go
+++ b/gfapi/volume.go
@@ -122,6 +122,14 @@ const (
 //
 // Returns 0 on success and, non 0 and an error on failure.
 func (v *Volume) SetLogging(name string, logLevel LogLevel) (int, error) {
+
+	if name == "" {
+		// a new logfile will be created in default log directory associated
+		// with the glusterfs installation (/var/log/glusterfs)
+		ret, err := C.glfs_set_logging(v.fs, nil, C.int(logLevel))
+		return int(ret), err
+	}
+
 	if _, err := os.Stat(path.Dir(name)); err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
From the C API:

int glfs_set_logging (glfs_t *fs, const char *logfile, int loglevel)

@logfile: The logfile to be used for logging. Will be created if it does not
          already exist (provided system permissions allow). If NULL, a new
          logfile will be created in default log directory associated with
          the glusterfs installation.

Signed-off-by: Prashanth Pai <ppai@redhat.com>